### PR TITLE
Only track `data-analytics-*` element props

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -46,7 +46,7 @@ function aliasFactory(key) {
 }
 
 // Handle click events
-async function evtHandle(track, key, e) {
+async function eventHandle(track, key, e) {
   // Only track elements with data-analytics=true
   if (!e.target.dataset.analytics) {
     return;
@@ -82,7 +82,7 @@ export default function init(key) {
   const track = trackFactory(key);
 
   // Listen to all click events in a page and track if enabled
-  window.addEventListener('click', e => evtHandle(track, key, e));
+  window.addEventListener('click', e => eventHandle(track, key, e));
 
   return {
     track,

--- a/src/load-script.js
+++ b/src/load-script.js
@@ -1,9 +1,16 @@
+import shimGlobalAnalytics from './shim-global-analytics';
+
 export default function loadScript(key) {
   return new Promise((res, rej) => {
     // If we have already loaded the script return window.analytics
     if (window.analytics) {
       return res();
     }
+
+    // Create our global event queue to catch any events that
+    // occur during script load
+    shimGlobalAnalytics();
+
     // Load in our external analytics script see this page for details:
     // https://developer.mozilla.org/en-US/docs/Web/API/HTMLScriptElement
     // Create our script

--- a/src/shim-global-analytics.js
+++ b/src/shim-global-analytics.js
@@ -1,0 +1,57 @@
+export default function shimGlobalAnalytics() {
+  // Create a queue, but don't obliterate an existing one!
+  const analytics = window.analytics || [];
+  window.analytics = analytics;
+
+  // If the real analytics.js is already on the page return.
+  if (analytics.initialize) return;
+
+  // If the snippet was invoked already show an error.
+  if (analytics.invoked) {
+    if (window.console && console.error) {
+      console.error('Segment snippet included twice.');
+    }
+    return;
+  }
+
+  // Invoked flag, to make sure the snippet
+  // is never invoked twice.
+  analytics.invoked = true;
+
+  // A list of the methods in Analytics.js to stub.
+  analytics.methods = [
+    'trackSubmit',
+    'trackClick',
+    'trackLink',
+    'trackForm',
+    'pageview',
+    'identify',
+    'reset',
+    'group',
+    'track',
+    'ready',
+    'alias',
+    'debug',
+    'page',
+    'once',
+    'off',
+    'on',
+  ];
+
+  // Define a factory to create stubs. These are placeholders
+  // for methods in Analytics.js so that you never have to wait
+  // for it to load to actually record data. The `method` is
+  // stored as the first argument, so we can replay the data.
+  analytics.factory = function(method) {
+    return function(...args) {
+      args.unshift(method);
+      analytics.push(args);
+      return analytics;
+    };
+  };
+
+  // For each of our methods, generate a queueing stub.
+  analytics.methods.forEach(key => {
+    analytics[key] = analytics.factory(key);
+  });
+}

--- a/test/index.html
+++ b/test/index.html
@@ -15,8 +15,9 @@
     <button
       id="test-3"
       data-analytics="true"
-      data-test="test"
-      data-payload="payload"
+      data-analytics-test="test"
+      data-analytics-payload="payload"
+      data-not-passed="true"
     >
       This should fire analytics with data
     </button>


### PR DESCRIPTION
Currently if we have an element like this:

```html
<a data-analytics=true data-key=test>Link</a>
```

We would get a payload like this 

```js
{ key: test }
```

We should be more explicit to avoid cluttering our events with random data, the new api looks like this:

```html
<a data-analytics=true data-analytics-key=test>Link</a>
```
to get this:

```js
{ key: test }
```