### PR TITLE
feat: send tracking messages to host page.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,9 @@ function trackFactory(key, getGlobalData) {
   return async (event, data = {}) => {
     const { track } = await loadAnalytics(key);
     const compoundedData = Object.assign({}, getGlobalData(), data);
+    if ('parentIFrame' in window) {
+      window.parentIFrame.sendMessage({ type: 'track', data: compoundedData });
+    }
     return track(event, compoundedData);
   };
 }


### PR DESCRIPTION
For https://festicket.atlassian.net/browse/FES-8565, we need to be able to pass messages up from the parent iframe to the host page. For this reason, we utilise the `sendMessage` method of the iframe resizer library - https://github.com/davidjbradshaw/iframe-resizer#sendmessagemessagetargetorigin.

On putting a console.log statement, we can see that the message is being sent to the iframe in case of embedded festivals

![image](https://user-images.githubusercontent.com/7420460/49155101-1cb6d200-f340-11e8-9640-04ec69df61c5.png)
